### PR TITLE
docs: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # cookiecutter-jina
 
+## Notice
+
+As of 26 August 2020 we are deprecating cookiecutter-jina. Unfortunately cookiecutter doesn't work well with a project of Jina's complexity, and it no longer supports any Jina version beyond 0.3.0. Rest assured we're currently working on alternative solutions to help developers quickly and easily create their Flows, which we will post here when they are ready.
+
+---
+
 [![Jina](https://github.com/jina-ai/jina/blob/master/.github/badges/jina-badge.svg?raw=true  "We fully commit to open-source")](https://get.jina.ai)
 
 Cookiecutter template for a Jina project


### PR DESCRIPTION
Cookiecutter no longer works, so I'm issuing a deprecation notice here. Once this goes through we should archive the repo to make it read-only