### PR TITLE
Changes for Depth range - recursive doc structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Generate a Jina project:
 cookiecutter gh:jina-ai/cookiecutter-jina
 ```
 
+## Exporting Environment Variables
+
+Before running ```python app.py```, set environment variables like ```MAX_DOCS``` and ```DATA_PATH``` using export:
+
+For instance: ```export DATA_PATH='data/startrek_tng.csv```
+
 ## Fork This / Create Your Own
 
 If you have differences in your preferred setup, I encourage you to fork this

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,5 +8,5 @@
   "public_port": "65481",
   "parallel": "2",
   "shards": "2",
-  "version": "0.0.3"
+  "version": "0.0.1"
 }

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -17,6 +17,9 @@ To install it in editable mode
 ```bash
 pip install -e .
 ```
+## Set environment variables
+
+Set env variables like ```DATA_PATH``` and ```MAX_DOCS```
 
 ## Run
 
@@ -42,6 +45,8 @@ To query
 ```bash
 docker run -p {{cookiecutter.public_port}}:{{cookiecutter.public_port}} -e "JINA_PORT=65481" jinaai/hub.app.{{ cookiecutter.project_slug }}:{{cookiecutter.version}} search
 ```
+## Note:
+The ```depth_range``` parameter in Flow and Pod YAML can be set according to the requirement of the implementation. This is used for recursive document structure in Jina.
 
 ## License
 

--- a/{{ cookiecutter.project_slug }}/extra-requirements.txt
+++ b/{{ cookiecutter.project_slug }}/extra-requirements.txt
@@ -1,0 +1,53 @@
+# https://hanxiao.io/2019/11/07/A-Better-Practice-for-Managing-extras-require-Dependencies-in-Python/
+# FORMAT
+# Put your extra requirements here in the following format
+#
+# package[version]: tag1, tag2, ...
+#
+# AVAILABLE TAGS
+#
+# nlp, cv, audio, numeric, index, http, sse, framework, perf, network
+#
+# REMARKS ON TAGS
+# 1. Try to reuse the existing tags if possible.
+#    If you intend to create a new tag, keep it alphabetical, short and general
+# 2. Package name itself is a tag already, so you don't need to tag it again.
+#    For example, 'flair>=0.4.1: flair' is redundant
+# 3. Tag order doesn't matter; case-sensitive; duplicated tag will be ignored
+# 4. Tag `all` is reserved for representing all packages
+
+scipy>=1.4.1:               index, numeric
+flask:                      devel, http, sse
+flask_cors:                 devel, http, sse
+nmslib>=1.6.3:              index
+docker:                     devel, network, hub
+torch>=1.1.0:               framework
+transformers>=2.6.0:        nlp
+flair:                      nlp
+paddlepaddle:               framework, py37
+paddlehub:                  framework, py37
+tensorflow>=2.0:            framework
+tensorflow-hub:             framework, py37
+torchvision>=0.3.0:         framework, cv
+onnx:                       framework, py37
+onnxruntime:                framework, py37
+Pillow:                     cv
+annoy>=1.9.5:               index
+sklearn:                    numeric
+plyvel:                     index
+jieba:                      nlp
+lz4:                        devel, perf, network
+gevent:                     http, devel
+python-magic:               http, devel
+pymilvus:                   index
+deepsegment:                nlp
+ngt:                        index, py37
+librosa>=0.7.2:             audio
+uvloop:                     devel, perf
+numpy:                      core
+pyzmq>=17.1.0:              core
+protobuf:                   core
+grpcio:                     core
+ruamel.yaml>=0.15.89:       core
+tornado>=5.1.0:             core
+cookiecutter:               hub, devel

--- a/{{ cookiecutter.project_slug }}/flows/index.yml
+++ b/{{ cookiecutter.project_slug }}/flows/index.yml
@@ -22,3 +22,30 @@ pods:
     uses: _merge
     needs: [doc_idx, chunk_idx]
     read_only: true
+requests:
+  on:
+    IndexRequest:
+      - !VectorIndexDriver
+        with:
+          executor: vecidx
+          traverse_on: chunks
+          depth_range: [1, 1]
+      - !KVIndexDriver
+        with:
+          executor: chunkidx
+          traverse_on: chunks
+          depth_range: [1, 1]
+    SearchRequest:
+      - !VectorSearchDriver
+        with:
+          executor: vecidx
+          top_k: 5
+          traverse_on: chunks
+          depth_range: [0, 0]
+      - !KVSearchDriver
+        with:
+          executor: chunkidx
+          key: id
+          #traverse_on: chunk_matches
+          traverse_on: matches
+          depth_range: [0, 1]

--- a/{{ cookiecutter.project_slug }}/pods/doc.yml
+++ b/{{ cookiecutter.project_slug }}/pods/doc.yml
@@ -4,3 +4,15 @@ with:
 metas:
   name: doc_indexer  # a customized name
   workspace: $WORKDIR
+requests:
+  on:
+    IndexRequest:
+      - !KVIndexDriver
+        with:
+          executor: doc_indexer
+          depth_range: [0, 0]
+    SearchRequest:
+      - !KVSearchDriver
+        with:
+          executor: doc_indexer
+          traverse_on: matches

--- a/{{ cookiecutter.project_slug }}/pods/encode.yml
+++ b/{{ cookiecutter.project_slug }}/pods/encode.yml
@@ -11,3 +11,15 @@ with:
   model_name: distilbert-base-cased
   max_length: 96
 {%- endif %}
+requests:
+  on:
+    IndexRequest:
+      - !EncodeDriver
+        with:
+          traverse_on: chunks
+          depth_range: [1, 1]
+    SearchRequest:
+      - !EncodeDriver
+        with:
+          traverse_on: chunks
+          depth_range: [0, 0]

--- a/{{ cookiecutter.project_slug }}/requirements.txt
+++ b/{{ cookiecutter.project_slug }}/requirements.txt
@@ -1,4 +1,5 @@
 jina==0.5.0
+jina[http]==0.5.0
 {%- if cookiecutter.task_type | lower == 'nlp' %}
 transformers==3.0.2
 torch>=1.5.1


### PR DESCRIPTION
Changes made:

- Doc indexer to use depth range 0 for querying and 1 while indexing

- Jina requirements to also include ` jina[http]`

-  Changes to `index` and `encode` yaml for depth range

-  Changes to `README` for ```Data path and Depth Range``` configurations

-  Reverted version in `cookiecutter.json` back to `0.0.1`

-  Added extra requirements