### PR TITLE
fix: env vars must be parsed to int

### DIFF
--- a/{{ cookiecutter.project_slug }}/app.py
+++ b/{{ cookiecutter.project_slug }}/app.py
@@ -5,7 +5,7 @@ import sys
 
 from jina.flow import Flow
 
-num_docs = os.environ.get('MAX_DOCS', 500)
+num_docs = int(os.environ.get('MAX_DOCS', 500))
 
 def config():
     parallel = {{cookiecutter.parallel}} if sys.argv[1] == 'index' else 1


### PR DESCRIPTION
When reading from `os.environ`, they are all string by default. A parsing is needed.