### PR TITLE
fix: model name parameter named correctly

### DIFF
--- a/{{ cookiecutter.project_slug }}/pods/encode.yml
+++ b/{{ cookiecutter.project_slug }}/pods/encode.yml
@@ -7,6 +7,6 @@ with:
 !TransformerTorchEncoder
 with:
   pool_strategy: auto
-  model_name: distilbert-base-cased
+  pretrained_model_name_or_path: distilbert-base-cased
   max_length: 96
 {%- endif %}


### PR DESCRIPTION
This fixed the parameter naming and makes indexing faster, since the correct model is used. The paramter name `model_name` is deprecated since some time.