### PR TITLE
fix(nlp): missing torch req

### DIFF
--- a/{{ cookiecutter.project_slug }}/requirements.txt
+++ b/{{ cookiecutter.project_slug }}/requirements.txt
@@ -1,2 +1,5 @@
 jina[devel,torch,tensorflow]=={{ cookiecutter.jina_version }}
 transformers==3.5.1
+{%- if cookiecutter.task_type | lower == 'nlp' %}
+torch==1.7.1
+{%- endif %}


### PR DESCRIPTION
Jina apps created using current cookiecutter version don't work with latest Jina version. So don't expect this PR to make it actually work again! This just fixes one of many issues that we'll need to resolve (because `jina hub new` uses cookiecutter)
