### PR TITLE
fix: remove SegmentDriver and add CraftDriver

### DIFF
--- a/{{ cookiecutter.project_slug }}/pods/craft.yml
+++ b/{{ cookiecutter.project_slug }}/pods/craft.yml
@@ -18,7 +18,7 @@ metas:
 requests:
   on:
     IndexRequest:
-      - !SegmentDriver
+      - !CraftDriver
         with:
           executor: img_read
       - !CraftDriver
@@ -26,7 +26,7 @@ requests:
           executor: img_norm
     SearchRequest:
       - !URI2Buffer {}
-      - !SegmentDriver
+      - !CraftDriver
         with:
           executor: img_read
       - !CraftDriver


### PR DESCRIPTION
`ImageReader` should use `CraftDriver` and not `SegmentDriver`