### PR TITLE
docs: refer to requirements.txt directly in readme

### DIFF
--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -9,14 +9,9 @@
 ## Install
 
 ```bash
-pip install .
+pip install -r requirements.txt
 ```
 
-To install it in editable mode
-
-```bash
-pip install -e .
-```
 ## Set environment variables
 
 Set env variables like ```JINA_DATA_PATH``` and ```MAX_DOCS```


### PR DESCRIPTION
Hi!

As the template doesn't generate a `setup.py`, here a small amend to get started without Docker.