### PR TITLE
chore: bump default initial version in cookiecutter config

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,5 +9,5 @@
   "public_port": "65481",
   "parallel": "2",
   "shards": "2",
-  "version": "0.0.1"
+  "version": "0.1.0"
 }


### PR DESCRIPTION
Hi!

Another small amend: use 0.1.0 instead of 0.0.1 as default initial version for the development phase, as semver.org [suggests](https://semver.org/#how-should-i-deal-with-revisions-in-the-0yz-initial-development-phase).