### PR TITLE
feat: use version matching clause

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
   "project_name": "My Neural Search Project",
-  "jina_version": "0.8.2",
+  "jina_version": "1.0",
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
   "author_name": "Jina's friend",
   "project_short_description": "A demo neural search project that uses Jina. Jina is the cloud-native neural search framework powered by state-of-the-art AI and deep learning.",

--- a/{{ cookiecutter.project_slug }}/requirements.txt
+++ b/{{ cookiecutter.project_slug }}/requirements.txt
@@ -1,5 +1,1 @@
-jina[devel,torch,tensorflow]=={{ cookiecutter.jina_version }}
-transformers==3.5.1
-{%- if cookiecutter.task_type | lower == 'nlp' %}
-torch==1.7.1
-{%- endif %}
+jina[devel,framework{%- if cookiecutter.task_type | lower == 'nlp' %},nlp{%- endif %}]=={{ cookiecutter.jina_version }}.*


### PR DESCRIPTION
Hi!

I looked at the [CHANGELOG](https://github.com/jina-ai/jina/blob/master/CHANGELOG.md) and couldn't quickly spot breaking changes until 1.0.7 versus 0.8.2 (are there any that need to be considered here, since the major version was bumped?). I've made the changes below assuming semantic versioning (dropping patch version here affects both dockerhub and pypi, see below), but as it's a major version bump, this PR might need some extra eyes to ensure the bump to v1 is fine.

Changes:
- Bump default jina version in `cookiecutter.json` from 0.8.2 to 1.0 (but entering a patch version will also still work).
  - This is fine for pip, as this PR also switches to a [version matching clause](https://www.python.org/dev/peps/pep-0440/#version-matching)  in requirements.txt.
    - For entering patch versions, luckily `pip install jina==1.0.7.*` successfully installs 1.0.7, as the trailing `.*` is explicitly allowed (see link above), and can be hard-coded in requirements.txt. The alternative was a [compatible release clause](https://www.python.org/dev/peps/pep-0440/#compatible-release), but as `jina~=1.0` is equivalent to `jina>=1.0,<2`, pip would allow e.g. 1.1, meaning divergence with the docker tag.
  - This is fine for the Dockerfile too, as jinaai/jina:1.0 will point to the same version that pip will be installing.
- Switch to jina's nice extras_require setup to get the right versions of tensorflow and torch (in case of `nlp` task type)
  - Added `framework` extra, to replace the seemingly deprecated `tensorflow` extra
  - Rely on `nlp` extra to get torch instead of hard coding/pinning here.
- Breaking change:
  - no longer install `transformers` by default (which fetches torch), rather rely on `nlp` extra.

Side question: do you already have plans for some checks for this repo? Maybe something like:
- Ensure the project creates successfully (and maybe even runs successfully both in local install and in docker):
  ```bash
  cookiecutter --no-input .  # not sure this works for the choice-type inputs, maybe it just picks the first
  cd my_neural_search_project
  pip install -r requirements.txt
  python app.py index  # etc
  docker build .  # etc
  ```
- If there were pre-commit hooks set up, do a round of `pre-commit run --all-files` and ensure the hooks will start passing after that, to ensure there are no weird things happening in the PR
- Any other sanity checks that wouldn't be caught by actually running `app.py`